### PR TITLE
Fix error check in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-# pgerror [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/omeid/pgerror)  [![Build Status](https://travis-ci.org/omeid/pgerror.svg?branch=master)](https://travis-ci.org/omeid/pgerror) [![Go Report Card](https://goreportcard.com/badge/github.com/omeid/pgerror)](https://goreportcard.com/report/github.com/omeid/pgerror)
+# pgerror [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/omeid/pgerror) [![Build Status](https://travis-ci.org/omeid/pgerror.svg?branch=master)](https://travis-ci.org/omeid/pgerror) [![Go Report Card](https://goreportcard.com/badge/github.com/omeid/pgerror)](https://goreportcard.com/report/github.com/omeid/pgerror)
 
 pgerror is a collection of helper functions to use with github.com/lib/pq Postgresql Database driver for Go Programming language.
-
 
 ```go
 
 // example use:
 _, err = stmt.Exec(SomeInsertStateMent, params...)
 if err != nil {
-  if e := pgerror.UniqueViolation(err); e == nil {
+  if e := pgerror.UniqueViolation(err); e != nil {
   // you can use e here to check the fields et al
     return SomeThingAlreadyExists
   }
@@ -18,6 +17,6 @@ if err != nil {
 
 ```
 
-err := 
 ### LICENSE
-  [MIT](LICENSE).
+
+[MIT](LICENSE).


### PR DESCRIPTION
Hi! Thanks for this useful library. I was about to work something like this into my own project. I noticed a small issue on the example in the readme where `e` is being checked against nil which then enters the block where code would be if the type assertion had passed. This PR cleans up the readme.